### PR TITLE
Remove metadata

### DIFF
--- a/ethereum/Webaverse.sol
+++ b/ethereum/Webaverse.sol
@@ -166,13 +166,11 @@ contract Webaverse is WebaverseVoucher, OwnableUpgradeable {
      * @param to The address on which the NFT will be minted(claimed).
      * @param data The data to store when claim.
      * @param name The name to store when claim.
-     * @param level The level to store when claim.
      * @param voucher A signed NFTVoucher that describes the NFT to be redeemed.
      **/
     function claimServerDropNFT(
         address to,
         string memory name,
-        string memory level,
         bytes memory data,
         NFTVoucher calldata voucher
     ) public {
@@ -190,7 +188,7 @@ contract Webaverse is WebaverseVoucher, OwnableUpgradeable {
         // make sure signature is valid and get the address of the signer
         address signer = verifyVoucher(voucher);
 
-        _nftContract.mintServerDropNFT(signer, to, name, level, data, voucher);
+        _nftContract.mintServerDropNFT(signer, to, name, data, voucher);
     }
 
     /**

--- a/ethereum/Webaverse.sol
+++ b/ethereum/Webaverse.sol
@@ -165,12 +165,10 @@ contract Webaverse is WebaverseVoucher, OwnableUpgradeable {
      * @notice Claims(Mints) the a single Server Drop NFT with given parameters.
      * @param to The address on which the NFT will be minted(claimed).
      * @param data The data to store when claim.
-     * @param name The name to store when claim.
      * @param voucher A signed NFTVoucher that describes the NFT to be redeemed.
      **/
     function claimServerDropNFT(
         address to,
-        string memory name,
         bytes memory data,
         NFTVoucher calldata voucher
     ) public {
@@ -188,7 +186,7 @@ contract Webaverse is WebaverseVoucher, OwnableUpgradeable {
         // make sure signature is valid and get the address of the signer
         address signer = verifyVoucher(voucher);
 
-        _nftContract.mintServerDropNFT(signer, to, name, data, voucher);
+        _nftContract.mintServerDropNFT(signer, to, data, voucher);
     }
 
     /**

--- a/ethereum/WebaverseVoucher.sol
+++ b/ethereum/WebaverseVoucher.sol
@@ -23,8 +23,6 @@ contract WebaverseVoucher is EIP712Upgradeable {
     struct NFTVoucher {
         // The id of the token to be redeemed. Must be unique - if another token with this ID already exists, the claim function will revert.
         uint256 tokenId;
-        // The hash of metadata in the ipfs
-        string metadataurl;
         // In case of ERC20 and ERC1155 the balance should be greater than 1. For ERC721 it must be set to 1.
         uint256 balance;
         // The valid nonce value of the NFT creator, fetched through _nonces mapping.
@@ -75,10 +73,9 @@ contract WebaverseVoucher is EIP712Upgradeable {
                 keccak256(
                     abi.encode(
                         keccak256(
-                            "NFTVoucher(uint256 tokenId,string metadataurl,uint256 balance,uint256 nonce,uint256 expiry)"
+                            "NFTVoucher(uint256 tokenId,uint256 balance,uint256 nonce,uint256 expiry)"
                         ),
                         voucher.tokenId,
-                        keccak256(abi.encodePacked(voucher.metadataurl)),
                         voucher.balance,
                         voucher.nonce,
                         voucher.expiry

--- a/ethereum/WebaverseVoucher.sol
+++ b/ethereum/WebaverseVoucher.sol
@@ -23,6 +23,8 @@ contract WebaverseVoucher is EIP712Upgradeable {
     struct NFTVoucher {
         // The id of the token to be redeemed. Must be unique - if another token with this ID already exists, the claim function will revert.
         uint256 tokenId;
+        // The URL of token's content - most likely be a metaversefile directory. But it could also be a GH pages or similar.
+        string contenturl;
         // In case of ERC20 and ERC1155 the balance should be greater than 1. For ERC721 it must be set to 1.
         uint256 balance;
         // The valid nonce value of the NFT creator, fetched through _nonces mapping.
@@ -73,9 +75,10 @@ contract WebaverseVoucher is EIP712Upgradeable {
                 keccak256(
                     abi.encode(
                         keccak256(
-                            "NFTVoucher(uint256 tokenId,uint256 balance,uint256 nonce,uint256 expiry)"
+                            "NFTVoucher(uint256 tokenId,string contenturl,uint256 balance,uint256 nonce,uint256 expiry)"
                         ),
                         voucher.tokenId,
+                        keccak256(abi.encodePacked(voucher.contenturl)),
                         voucher.balance,
                         voucher.nonce,
                         voucher.expiry


### PR DESCRIPTION
- Remove attribute on 1155 contract
- Remove level on `Webaverse.sol`
- Renamed `metadataurl` to `contenturl`.
- `uri` function returns the URI in the format of `[baseURI]/[id]`.
  - You can retrieve metadata such as name, level etc from token api instead: https://tokens.webaverse.com/1

- Q&A
  - Q: double check: we are abandoning these metadata from 1155 contract right?
  - A: no we aren't abandoning them, we are simply getting it from the metaversefile